### PR TITLE
Changes to TCP/UDP parsing

### DIFF
--- a/conf.d/patterns/pf-12.2019.grok
+++ b/conf.d/patterns/pf-12.2019.grok
@@ -11,7 +11,7 @@ PF_IPv6_VAR %{WORD:Type},%{WORD:Option},%{WORD:Flags},%{WORD:Flags}
 PF_IPv6_ICMP
 
 # PROTOCOL
-PF_TCP_DATA %{INT:[source][port]},%{INT:[destination][port]},%{INT:[transport][data_length]},(?<tcp_flags>(\w*)?),(?<sequence_number>(\d*)?),(?<ack_number>(\d*)?),(?<window_size>(\d*)?),(?<tcp_urg_data>(\w*)?),%{GREEDYDATA:tcp_options}
+PF_TCP_DATA %{INT:[source][port]},%{INT:[destination][port]},%{INT:[transport][data_length]},(?<tcp_flags>(\w*)?),(?<sequence_number>(\d*)?):?\d*,(?<ack_number>(\d*)?),(?<window_size>(\d*)?),(?<tcp_urg_data>(\w*)?),%{GREEDYDATA:tcp_options}
 PF_UDP_DATA %{INT:[source][port]},%{INT:[destination][port]},%{INT:[transport][data_length]}
 PF_IGMP_DATA datalength=%{INT:[network][packets]}
 PF_ICMP_DATA %{PF_ICMP_TYPE}%{PF_ICMP_RESPONSE}

--- a/conf.d/patterns/pf-12.2019.grok
+++ b/conf.d/patterns/pf-12.2019.grok
@@ -12,7 +12,7 @@ PF_IPv6_ICMP
 
 # PROTOCOL
 PF_TCP_DATA %{INT:[source][port]},%{INT:[destination][port]},%{INT:[transport][data_length]},(?<tcp_flags>(\w*)?),(?<sequence_number>(\d*)?):?\d*,(?<ack_number>(\d*)?),(?<window_size>(\d*)?),(?<tcp_urg_data>(\w*)?),%{GREEDYDATA:tcp_options}
-PF_UDP_DATA %{INT:[source][port]},%{INT:[destination][port]},%{INT:[transport][data_length]}
+PF_UDP_DATA %{INT:[source][port]},%{INT:[destination][port]},%{INT:[transport][data_length]}$
 PF_IGMP_DATA datalength=%{INT:[network][packets]}
 PF_ICMP_DATA %{PF_ICMP_TYPE}%{PF_ICMP_RESPONSE}
 PF_ICMP_TYPE (?<icmp_type>(request|reply|unreachproto|unreachport|unreach|timeexceed|paramprob|redirect|maskreply|needfrag|tstamp|tstampreply)),


### PR DESCRIPTION
# Pull Request Template

## Description

It appears that the tcp sequence # can be a range:
```
6,,,1000000104,ovpns4,match,block,out,4,0x20,,48,37755,0,DF,6,tcp,86,72.52.192.72,10.21.2.14,993,52016,46,PA,2479650932:2479650978,3451974371,1432,,
```

Also, if the PF_TCP_DATA pattern does not match the tcp data - the PF_UDP_DATA pattern will (partially) match it.  This can disguise issues with the tcp pattern.  This adds an end of line anchor to the UDP pattern to prevent that.  Not sure if that is desired or not.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Original Configuration
- [X] Adjusted Configuration

**Test Configuration**:
* Elastic Stack Version: Logstash 7.6.1, elasticsearch 7.4.2, opendistroforelasticsearch-kibana-1.4.0

## Checklist:

- [x] Code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
