### PR TITLE
[event][created] year hack

### DIFF
--- a/data/configurations/01-inputs.conf
+++ b/data/configurations/01-inputs.conf
@@ -36,5 +36,21 @@ filter {
       rename => { "[message]" => "[event][original]"}
       remove_tag => "Ready"
     }
+
+    # pfSense < v2.5 uses syslog format RFC 3164. pfSense > 2.5 uses either syslog format RFC 3164 or RFC 5424
+    # pfSense syslog RFC 3164 does not have a year. This is an imperfect hack to add a year to the event using the current year.
+    # Example input: May  3 18:16:05
+    # Example output: 2020-05-03T18:16:05.000Z
+    grok {
+      match => { "[event][created]" => "%{MONTH:[@metadata][syslogtimestampmonth]}\s*%{MONTHDAY:[@metadata][syslogtimestampday]}\s%{TIME:[@metadata][syslogtimestamptime]}"}
+    }
+    mutate {
+      add_field => {"[@metadata][currentyear]" => "%{+YYYY}"} 
+      add_field => {"[@metadata][syslogtimestamphack]" => "%{[@metadata][currentyear]} %{[@metadata][syslogtimestampmonth]} %{[@metadata][syslogtimestampday]} %{[@metadata][syslogtimestamptime]}"}
+    }
+    date {
+        match => ["[@metadata][syslogtimestamphack]", "yyyy MMM dd HH:mm:ss", "yyyy MMM d HH:mm:ss"]
+        target => "[event][created]"
+    }
   }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

pfSense uses default BSD syslog format (RFC 3164) and it does not have a year. This is an imperfect hack to add a year to the event using the current year. This change then allows the ElasticSearch template to be updated so that [event][created] is a data type of date which is what ECS wants. 

You get this with pfSense: May  3 18:16:05
It gets transformed into this: 2020-05-03T18:16:05.000Z

Note that pfSense 2.5 allows you to change the syslog output to 5424 which includes the year.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Lightly tested and needs peer review.
