### PR TITLE
Add alias and description to rule with CSV

### DIFF
--- a/etc/logstash/conf.d/35-rules-desc.conf
+++ b/etc/logstash/conf.d/35-rules-desc.conf
@@ -1,30 +1,27 @@
-# 35-rules.conf
-#################################################
-# Checks for the presense of the tracker field, #
-# if present runs translates the tracker into a #
-# referenced description.                       #
-#################################################
+# 35-rules-desc.conf
+#####################################################
+# Checks for the presense of the rule_number field, #
+# if present runs translates the rule_number into a #
+# referenced description.                           #
+#####################################################
 filter {
   if [type] == "firewall" {
-    if [tracker] {
+    if [rule_number] {
       mutate {
-        convert => ["tracker", "string"]
+        convert => ["rule_number", "string"]
       }
     }
-    if [tracker] {
+    if [rule_number] {
       translate {
-        field => "[tracker]"
-        destination => "[rule][description]"
-        dictionary => {
-        "0" => "null"
-
-        }
-        fallback => "no match"
+        field => "[rule_number]"
+        destination => "[rule][alias]"
+        dictionary_path => "/etc/logstash/conf.d/database/rule-names.csv"
+        refresh_interval => 60
+        refresh_behaviour => replace
+        fallback => "%{rule_number}"
       }
-    }
-    if [rule][description] {
       mutate {
-        add_tag => "Rule_Description"
+        add_field => { "[rule][description]" => "%{[interface][alias]}: %{[rule][alias]}" }
       }
     }
   }

--- a/etc/logstash/conf.d/database/rule-names.csv
+++ b/etc/logstash/conf.d/database/rule-names.csv
@@ -1,0 +1,2 @@
+"Rule","Label"
+"0","null"


### PR DESCRIPTION
## Description
Checks for the presense of the rule_number field, if present runs translates the rule_number into a referenced description.   

Fixes # (issue)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

Using Opnsense, I don't have access to the command to link the description to the rule so I looked for an easy way to update the description of my rules.
With a cvs file, I can update it simply and by using a "refresh_interval" of 60sec, my logstash is updated automatically (without having to restart logstash).