### PR TITLE
Change GeoIP db location to /var/lib

### DIFF
--- a/etc/pfelk/conf.d/30-geoip.conf
+++ b/etc/pfelk/conf.d/30-geoip.conf
@@ -18,12 +18,12 @@ filter {
       if "IP_Private_Source" not in [tags] {
         geoip {
           source => "[source][ip]"
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
           target => "[source][geo]"
         }
         geoip {
           default_database_type => 'ASN'
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
           source => "[source][ip]"
           target => "[source][as]"
         }
@@ -46,12 +46,12 @@ filter {
       if "IP_Private_Destination" not in [tags] {
         geoip {
           source => "[destination][ip]"
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
           target => "[destination][geo]"
         }
         geoip {
           default_database_type => 'ASN'
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
           source => "[destination][ip]"
           target => "[destination][as]"
         }
@@ -77,12 +77,12 @@ filter {
       if "IP_Private_HAProxy" not in [tags] {
         geoip {
           source => "[client][ip]"
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
           target => "[source][geo]"
         }
         geoip {
           default_database_type => 'ASN'
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
           source => "[client][ip]"
           target => "[source][as]"
        }

--- a/etc/pfelk/scripts/error-data.sh
+++ b/etc/pfelk/scripts/error-data.sh
@@ -16,7 +16,7 @@ echo "# Listing pfelk Directory Structure #" >> /etc/pfelk/logs/error.pfelk.log
 echo "#####################################\n" >> /etc/pfelk/logs/error.pfelk.log
 find /etc/pfelk/ | cat >> /etc/pfelk/logs/error.pfelk.log
 find /etc/logstash/ | cat >> /etc/pfelk/logs/error.pfelk.log
-find /usr/share/GeoIP/ | cat >> /etc/pfelk/logs/error.pfelk.log
+find /var/lib/GeoIP/ | cat >> /etc/pfelk/logs/error.pfelk.log
 #capture all config files
 echo "\n#####################################" >> /etc/pfelk/logs/error.pfelk.log
 echo "# pfelk Config File Details #########" >> /etc/pfelk/logs/error.pfelk.log

--- a/etc/pfelk/scripts/pfelk-installer.sh
+++ b/etc/pfelk/scripts/pfelk-installer.sh
@@ -655,7 +655,7 @@ select opt in "${options[@]}"
        rm --force "$geoip_temp" 2> /dev/null
        
     # GeoIP Cronjob
-       echo 00 17 * * 0 geoipupdate -d /usr/share/GeoIP > /etc/cron.weekly/geoipupdate
+       echo 00 17 * * 0 geoipupdate -d /var/lib/GeoIP > /etc/cron.weekly/geoipupdate
        sed -i 's/EditionIDs.*/EditionIDs GeoLite2-Country GeoLite2-City GeoLite2-ASN/g' /etc/GeoIP.conf
        maxmind_username=$(echo "${maxmind_username}")
        maxmind_password=$(echo "${maxmind_password}")
@@ -664,7 +664,7 @@ select opt in "${options[@]}"
        sed -i "s/AccountID.*/AccountID ${maxmind_username}/g" /etc/GeoIP.conf
        sed -i "s/LicenseKey.*/LicenseKey ${maxmind_password}/g" /etc/GeoIP.conf
        echo -e "\\n";
-       geoipupdate -d /usr/share/GeoIP
+       geoipupdate -d /var/lib/GeoIP
        sleep 2
        echo -e "\\n";;
        [Nn]*|"") 
@@ -1072,12 +1072,12 @@ ILM_option
 # MaxMind
 maxmind_geoip() {
 # MaxMind check to ensure GeoIP database files were downloaded - Success
-if [[ "${maxmind_install}" == 'true' ]] && [[ -f /usr/share/GeoIP/GeoLite2-City.mmdb ]] && [[ -f /usr/share/GeoIP/GeoLite2-ASN.mmdb ]]; then
+if [[ "${maxmind_install}" == 'true' ]] && [[ -f /var/lib/GeoIP/GeoLite2-City.mmdb ]] && [[ -f /var/lib/GeoIP/GeoLite2-ASN.mmdb ]]; then
   echo "\\n${GREEN}#${RESET} MaxMind Files Present"
   sleep 3
 fi
 # MaxMind check to ensure GeoIP database files are downloaded - Error Display
-if [[ "${maxmind_install}" == 'true' ]] && ! [[ -f /usr/share/GeoIP/GeoLite2-City.mmdb ]] && ! [[ -f /usr/share/GeoIP/GeoLite2-ASN.mmdb ]]; then
+if [[ "${maxmind_install}" == 'true' ]] && ! [[ -f /var/lib/GeoIP/GeoLite2-City.mmdb ]] && ! [[ -f /var/lib/GeoIP/GeoLite2-ASN.mmdb ]]; then
   echo -e "\\n${RED}#${RESET} Please Check Your MaxMind Configuration!"
   echo -e "${RED}#${RESET} MaxMind Files Where Not Found."
   echo -e "${RED}#${RESET} Defaulting to Elastic GeoIP Database Files."

--- a/experimental/conf.d/30-geoip.conf
+++ b/experimental/conf.d/30-geoip.conf
@@ -18,12 +18,12 @@ filter {
       if "IP_Private_Source" not in [tags] {
         geoip {
           source => "[source][ip]"
-  #MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+  #MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
           target => "[source][geo]"
         }
         geoip {
           default_database_type => 'ASN'
-  #MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+  #MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
           source => "[source][ip]"
           target => "[source][as]"
         }
@@ -46,12 +46,12 @@ filter {
       if "IP_Private_Destination" not in [tags] {
         geoip {
           source => "[destination][ip]"
-  #MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+  #MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
           target => "[destination][geo]"
         }
         geoip {
           default_database_type => 'ASN'
-  #MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+  #MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
           source => "[destination][ip]"
           target => "[destination][as]"
         }

--- a/experimental/conf.d/31-geoip_extended.conf
+++ b/experimental/conf.d/31-geoip_extended.conf
@@ -64,7 +64,7 @@ filter {
       if [server][as][system] == "public" {
         geoip {
           source => "[server][ip]"
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
 #MMR#          cache_size => "8192"
           target => "[server][geo]"
           fields => ["city_name", "continent_code", "country_code2", "country_name", "dma_code", "latitude", "longitude", "postal_code", "region_code", "region_name", "timezone"]
@@ -80,7 +80,7 @@ filter {
         }
         geoip {
           source => "[server][ip]"
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
 #MMR#          cache_size => "8192"
           target => "[server][as]"
           fields => ["autonomous_system_number", "autonomous_system_organization"]
@@ -119,7 +119,7 @@ filter {
       if [client][as][system] == "public" {
         geoip {
           source => "[client][ip]"
- #MMR#         database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+ #MMR#         database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
  #MMR#         cache_size => "8192"
           target => "[client][geo]"
           fields => ["continent_code", "country_code2", "country_code3", "country_name", "dma_code", "latitude", "longitude", "postal_code", "region_code", "region_name", "timezone"]
@@ -135,7 +135,7 @@ filter {
         }
         geoip {
           source => "[client][ip]"
- #MMR#         database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+ #MMR#         database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
  #MMR#         cache_size => "8192"
           target => "[client][as]"
           fields => ["autonomous_system_number", "autonomous_system_organization"]


### PR DESCRIPTION
see discussion #259

/var/lib : Variable state information
https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s08.html
/usr/share : Architecture-independent data
https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html

/var/lib/GeoIP seems to be a location more fitting for the geoip db files

- [x] This change requires a documentation update
