### PR TITLE
Add "hirsute" to supported OS version

### DIFF
--- a/etc/pfelk/scripts/pfelk-installer.sh
+++ b/etc/pfelk/scripts/pfelk-installer.sh
@@ -321,7 +321,7 @@ get_distro() {
 }
 get_distro
 
-if ! [[ "${os_codename}" =~ (xenial|bionic|cosmic|disco|eoan|focal|stretch|buster|bullseye|bookworm)  ]]; then
+if ! [[ "${os_codename}" =~ (xenial|bionic|cosmic|disco|eoan|focal|stretch|buster|bullseye|bookworm|hirsute)  ]]; then
   clear
   header_red
   echo -e "${WHITE_R}#${RESET} This script is not made for your OS."


### PR DESCRIPTION
# Pull Request Template

## Description

${os_codename} = "hirsute" is the codename for Ubuntu (-Server) 21.04. I installed it with this line change and it worked without a flaw, so it should be added to the installer for future users.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Original Configuration
- [ ] Adjusted Configuration

**Test Configuration**:
* Elastic Stack Version: 7.12./7.13
* Linux Version/Type: Ubuntu Server 21.04.

## Checklist:

- [X] Code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas [I don't think that's needed for 1 line]
- [X] I have made corresponding changes to the documentation [None]
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
