### PR TITLE
Update PF Rule UUID Field Type

### DIFF
--- a/etc/pfelk/patterns/pfelk.grok
+++ b/etc/pfelk/patterns/pfelk.grok
@@ -37,7 +37,7 @@ OPENVPN (%{IP:[openvpn][user][ip]}.%{INT:[openvpn][user][port]})?(%{USERNAME:[op
 
 # PF
 PF_LOG_ENTRY %{PF_LOG_DATA}%{PF_IP_SPECIFIC_DATA}%{PF_IP_DATA}%{PF_PROTOCOL_DATA}?
-PF_LOG_DATA %{INT:[rule][ruleset]},%{INT:[rule][id]}?,,%{WORD:[rule][uuid]},%{DATA:[interface][name]},(?<[event][reason]>\b[\w\-]+\b),%{WORD:[event][action]},%{WORD:[network][direction]},
+PF_LOG_DATA %{INT:[rule][ruleset]},%{INT:[rule][id]}?,,%{DATA:[rule][uuid]},%{DATA:[interface][name]},(?<[event][reason]>\b[\w\-]+\b),%{WORD:[event][action]},%{WORD:[network][direction]},
 PF_IP_SPECIFIC_DATA %{PF_IPv4_SPECIFIC_DATA}|%{PF_IPv6_SPECIFIC_DATA}
 PF_IPv4_SPECIFIC_DATA (?<[network][type]>(4)),%{BASE16NUM:[pf][ipv4][tos]},%{WORD:[pf][ipv4][ecn]}?,%{INT:[pf][ipv4][ttl]},%{INT:[pf][ipv4][packet][id]},%{INT:[pf][ipv4][offset]},%{WORD:[pf][ipv4][flags]},%{INT:[network][iana_number]},%{WORD:[network][transport]},
 PF_IP_DATA %{INT:[pf][packet][length]},%{IP:[source][ip]},%{IP:[destination][ip]},

--- a/etc/pfelk/patterns/pfelk.grok
+++ b/etc/pfelk/patterns/pfelk.grok
@@ -37,7 +37,7 @@ OPENVPN (%{IP:[openvpn][user][ip]}.%{INT:[openvpn][user][port]})?(%{USERNAME:[op
 
 # PF
 PF_LOG_ENTRY %{PF_LOG_DATA}%{PF_IP_SPECIFIC_DATA}%{PF_IP_DATA}%{PF_PROTOCOL_DATA}?
-PF_LOG_DATA %{INT:[rule][ruleset]},%{INT:[rule][id]}?,,%{INT:[rule][uuid]},%{DATA:[interface][name]},(?<[event][reason]>\b[\w\-]+\b),%{WORD:[event][action]},%{WORD:[network][direction]},
+PF_LOG_DATA %{INT:[rule][ruleset]},%{INT:[rule][id]}?,,%{WORD:[rule][uuid]},%{DATA:[interface][name]},(?<[event][reason]>\b[\w\-]+\b),%{WORD:[event][action]},%{WORD:[network][direction]},
 PF_IP_SPECIFIC_DATA %{PF_IPv4_SPECIFIC_DATA}|%{PF_IPv6_SPECIFIC_DATA}
 PF_IPv4_SPECIFIC_DATA (?<[network][type]>(4)),%{BASE16NUM:[pf][ipv4][tos]},%{WORD:[pf][ipv4][ecn]}?,%{INT:[pf][ipv4][ttl]},%{INT:[pf][ipv4][packet][id]},%{INT:[pf][ipv4][offset]},%{WORD:[pf][ipv4][flags]},%{INT:[network][iana_number]},%{WORD:[network][transport]},
 PF_IP_DATA %{INT:[pf][packet][length]},%{IP:[source][ip]},%{IP:[destination][ip]},


### PR DESCRIPTION
# Pull Request Template

## Description

The latest OPNsense update seemed to change the output type of the rule uuid field from an integer to an alphanumeric. Using the `WORD` grok pattern instead of `INT` will capture both scenarios.

Fixes #324 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I used the Grok Debugger in Kibana to test the pattern change. I observed the change allowing the logged events in the issue to be parsed.

- [X] Original Configuration
- [X] Adjusted Configuration

**Test Configuration**:
* Elastic Stack Version: 7.13
* Linux Version/Type: Ubuntu 20.04
* Java Version: Built-in
* Elastic Stack Configuration Files:

## Checklist:

- [ ] Code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
