### PR TITLE
fix for #441: unbound grok pattern for TLDs

### DIFF
--- a/etc/pfelk/conf.d/05-apps.pfelk
+++ b/etc/pfelk/conf.d/05-apps.pfelk
@@ -261,6 +261,10 @@ filter {
         match => [ "[dns][question][name]", "(?<[dns][question][registered_domain]>[^.]+\.[^.]+)$" ] 
       }
     }
+    grok {
+      match => [ "[dns][question][name]", "(\.)?(?<[dns][question][tld]>[^.]+)$" ]
+    }
+
     mutate {
       remove_tag => "unbound-registered_domain"
     }


### PR DESCRIPTION
# Pull Request Template

## Description
grok pattern for unbound for extraction the TLD of the request

Fixes #441

## Type of change

Please delete options that are not relevant.
- [X ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X] Original Configuration
- [X] Adjusted Configuration

**Test Configuration**:
* Elastic Stack Version: 8.2.2
* Linux Version/Type: Ubuntu 22.04 LTS
* Java Version:  openjdk 18.0.1.1

## Checklist:

- [X] Code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
