### PR TITLE
pfelk_rule_generator.sh | remove extra content after rule name

### DIFF
--- a/etc/pfelk/scripts/pfelk_rule_generator.sh
+++ b/etc/pfelk/scripts/pfelk_rule_generator.sh
@@ -77,7 +77,7 @@ firewall_opt(){
 }
 
 opnsense_pfctl(){
-  pfctl -vv -sr | grep label | sed -r 's/@([[:digit:]]+).*"([^"]{32})"/"\2","\1"/g' | sort -k 1.1 > /tmp/pfelk_rules_pfctl.tmp
+  pfctl -vv -sr | grep label | sed -r 's/@([[:digit:]]+).*"([^"]{32})".*/"\2","\1"/g' | sort -k 1.1 > /tmp/pfelk_rules_pfctl.tmp
 }
 
 opnsense_opt1(){

--- a/etc/pfelk/scripts/pfelk_rule_sync.sh
+++ b/etc/pfelk/scripts/pfelk_rule_sync.sh
@@ -42,7 +42,7 @@ Script options:
 }
 
 opnsense_pfctl(){
-	pfctl -vv -sr | grep label | sed -r 's/@([[:digit:]]+).*"([^"]{32})"/"\2","\1"/g' | sort -k 1.1 > /tmp/pfelk_rules_pfctl.tmp
+	pfctl -vv -sr | grep label | sed -r 's/@([[:digit:]]+).*"([^"]{32})".*/"\2","\1"/g' | sort -k 1.1 > /tmp/pfelk_rules_pfctl.tmp
 }
 
 opnsense_opt1(){


### PR DESCRIPTION
## Description

When using tags in opnsense the tag is added after the rule name
label "char(32)" tag MYTAG_NAME
also when using the tag as a filter inside rules
label "char(32)" tagged MYTAG_NAME

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Original Configuration on OPNsense 23.1.5_4-amd64
