### PR TITLE
Update 02-firewall.pfelk

### DIFF
--- a/etc/pfelk/conf.d/02-firewall.pfelk
+++ b/etc/pfelk/conf.d/02-firewall.pfelk
@@ -47,8 +47,8 @@ filter {
           "[pf][id]" =>		       "%{[pf_csv][12]}"
           "[pf][offset]" =>	       "%{[pf_csv][13]}"
           "[pf][flags]" =>	       "%{[pf_csv][14]}"
-          "[network][protocol]" =>     "%{[pf_csv][15]}"
-          "[network][iana_number]" =>  "%{[pf_csv][16]}"
+          "[network]iana_number]" =>   "%{[pf_csv][15]}"
+          "[network][[protocol]" =>    "%{[pf_csv][16]}"
           "[pf][packet][length]" =>    "%{[pf_csv][17]}"
           "[source][ip]" =>	       "%{[pf_csv][18]}"
           "[destination][ip]" =>       "%{[pf_csv][19]}"
@@ -75,7 +75,7 @@ filter {
       # [UDP]
       # [ECS compliant fields] source.port, destination.port 
       # [Not ECS compliant fields] pf.data_length
-      if [network][iana_number] == "6" or [network][iana_number] == "17" {
+      if [network][[protocol] == "udp" {
         mutate {
           add_field => {
             "[source][port]" =>	        "%{[pf_csv][20]}"


### PR DESCRIPTION
OPNSENSE firewall logs were not correctly capturing TCP/UDP information.

1) IPv4 protocol and iana_number were around the wrong way for opnsense logs. I can't confirm for pfsense.  2) UDP section was using TCP number

Tested against OPNSENSE: 23.7.1_3

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Original Configuration
- [x] Adjusted Configuration

**Test Configuration**:
* Elastic Stack Version:
* Linux Version/Type:
* Java Version:
* Elastic Stack Configuration Files:

## Checklist:

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
