### PR TITLE
Update 30-geoip.pfelk

### DIFF
--- a/etc/pfelk/conf.d/30-geoip.pfelk
+++ b/etc/pfelk/conf.d/30-geoip.pfelk
@@ -18,12 +18,12 @@ filter {
       if "IP_Private_Source" not in [tags] {
         geoip {
           source => "[source][ip]"
-#MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
+#MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
         }
         geoip {
           source => "[source][ip]"
           default_database_type => 'ASN'
-#MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
+#MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
         }
         mutate {
           add_tag => "GeoIP_Source"
@@ -40,13 +40,13 @@ filter {
       if "IP_Private_Destination" not in [tags] {
         geoip {
           source => "[destination][ip]"
-#MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
+#MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
 #ECSv8#          target => "[destination]"
         }
         geoip {
           source => "[destination][ip]"
           default_database_type => 'ASN'
-#MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
+#MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
         }
         mutate {
           add_tag => "GeoIP_Destination"
@@ -66,12 +66,12 @@ filter {
       if "IP_Private_Proxy" not in [tags] {
         geoip {
           source => "[client][ip]"
-#MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
+#MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
         }
         geoip {
           source => "[client][ip]"
           default_database_type => 'ASN'
-#MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
+#MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
        }
         mutate {
           add_tag => "GeoIP_Source"


### PR DESCRIPTION
MaxMind uses a different location when using geoipupdate binary

# Pull Request Template

## Description

The GeoIP DB location in 30-geoip.pfelk is incorrect, or at least it was for me using the manual install docs, I changed the DB location and restarted, I can now see entries in Kibana and no more logstash errors.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I changed the GeoIP database locations in 30-geoip.pfelk and restarted logstash and it started without errors.

- [X] Original Configuration
- [X] Adjusted Configuration

**Test Configuration**:
* Elastic Stack Version: 8.11.1
* Linux Version/Type: 22.04
* Java Version: 17.0.9
* Elastic Stack Configuration Files: 30-geoip.pfelk

## Checklist:

- [X] Code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
