### PR TITLE
Fix source/destination bytes field errors caused by newline

### DIFF
--- a/etc/pfelk/conf.d/02-firewall.pfelk
+++ b/etc/pfelk/conf.d/02-firewall.pfelk
@@ -16,6 +16,7 @@ filter {
       copy => { "filter_message" => "pfelk_csv" }
     }
     mutate {
+      strip => "pfelk_csv"
       split => { "pfelk_csv" => "," }
     }
 


### PR DESCRIPTION
# Fix source/destination bytes field caused by newline

## Description
In OPNsense filterlog when source.bytes and destination.bytes are at the end of the log pf adds a newline. The \n is not stripped in Logstash and fields are ignored during indexing in Elasticsearch:

<img width="30%" alt="ignored" src="https://github.com/user-attachments/assets/d7c00df3-228a-43f7-8aa6-5edf9f56d273" />
<img width="30%" height="783" alt="source-bytes" src="https://github.com/user-attachments/assets/a656b6de-3708-4bdf-ba22-55ea4897907b" />
<img width="30%" height="374" alt="source-bytes-1" src="https://github.com/user-attachments/assets/a6f931d6-45bc-4cf2-b9b1-9bf9c826c70a" />

## Fixes
Strip newline for all filterlogs in logstash in 02-firewall.pfelk:
```
 strip => "pfelk_csv"
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I've tested it on my pfelk - OPNSense instance. I haven't tested on pfSense:
<img width="80%" alt="testing-2" src="https://github.com/user-attachments/assets/54747ccb-6daf-4c93-b32e-cbcdc461f294" />
After applying config I haven't noticed any crashes or ignored source/dest.bytes fields anymore:
<img width="80%" alt="testing" src="https://github.com/user-attachments/assets/e1cff0a2-52ee-4aa3-8958-1da4a21946f2" />

**Test Configuration**:
* Elastic Stack Version: 9.1.4
* Linux Version/Type: Debian 12 Bookworm
* Java Version: openjdk 24.0.2 2025-07-15
* Elastic Stack Configuration Files: pfelk 
* OPNsense 25.7.3-amd64


## Checklist:

- [X] Code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
